### PR TITLE
Interrupt casts when equipping items.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -676,7 +676,7 @@ bool Player::Create(ObjectGuid::LowType guidlow, const std::string& name, uint8 
             if( msg == EQUIP_ERR_OK )
             {
                 RemoveItem(INVENTORY_SLOT_BAG_0, i,true);
-                EquipItem( eDest, pItem, true);
+                EquipItem( eDest, pItem, true, false);
             }
             // move other items to more appropriate slots (ammo not equipped in special bag)
             else
@@ -10371,9 +10371,10 @@ InventoryResult Player::CanEquipItem( uint8 slot, uint16 &dest, Item *pItem, boo
 
                 if(IsInCombat()&& pProto->Class == ITEM_CLASS_WEAPON && m_weaponChangeTimer != 0)
                     return EQUIP_ERR_CANT_DO_RIGHT_NOW;         // maybe exist better err
-
+#ifdef LICH_KING
                 if(IsNonMeleeSpellCast(false))
                     return EQUIP_ERR_CANT_DO_RIGHT_NOW;
+#endif
             }
 
             uint8 eslot = FindEquipSlot( pProto, slot, swap );
@@ -11007,10 +11008,15 @@ Item* Player::EquipNewItem(uint16 pos, uint32 item, bool update)
     return nullptr;
 }
 
-Item* Player::EquipItem(uint16 pos, Item *pItem, bool update)
+Item* Player::EquipItem(uint16 pos, Item *pItem, bool update, bool interruptSpells)
 {
     if(pItem)
     {
+#ifndef LICH_KING
+        if (interruptSpells && IsNonMeleeSpellCast(false))
+            InterruptNonMeleeSpells(false);
+#endif
+
         AddEnchantmentDurations(pItem);
         AddItemDurations(pItem);
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2684,7 +2684,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         bool m_hasMovedInUpdate;
 
         //sun: keep EquipItem in private, they're really use to missuse
-        Item* EquipItem(uint16 pos, Item *pItem, bool update);
+        Item* EquipItem(uint16 pos, Item *pItem, bool update, bool interruptSpells = true);
 
     private:
         // internal common parts for CanStore/StoreItem functions

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3935,7 +3935,7 @@ void Spell::EffectSummonChangeItem(uint32 i)
             m_castItemGUID.Clear();
             m_castItemEntry = 0;
 
-            player->EquipItem(dest, pNewItem, true);
+            player->EquipItem(dest, pNewItem, true, false);
             player->AutoUnequipOffhandIfNeed();
             player->SendNewItem(pNewItem, 1, true, false);
             player->ItemAddedQuestCheck(newitemid, 1);


### PR DESCRIPTION
**Changes proposed**:

- Allow equipping items while casting.
- Interrupt casting when an item is equipped.

This makes it work the way mentioned in the patch notes.
> World of Warcraft Client Patch 2.4.3
> -  Equipping an item will now cancel any spell cast currently in progress.

**Issues addressed**: Fixes https://github.com/ValorenWoW/sunstrider-core/issues/59

**Tests performed**: works in game
