### PR TITLE
Implemented innate magic resistance for felhunter case.

### DIFF
--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1271,7 +1271,13 @@ void Guardian::UpdateResistances(uint32 school)
 
         // hunter and warlock pets gain 40% of owner's resistance
         if (IsPet())
+        {
             value += float(CalculatePct(m_owner->GetResistance(SpellSchools(school)), 40));
+
+            // "Felhunters have innate magic resistance, equal to twice its masters level." https://wow.gamepedia.com/index.php?title=Felhunter&oldid=1511849#Felhunter_Stats
+            if (GetEntry() == ENTRY_FELHUNTER)
+                value += m_owner->GetLevel() * 2;
+        }
 
         SetResistance(SpellSchools(school), int32(value));
     }


### PR DESCRIPTION
Warning: might be a hackfix but currently a lot of pet stats are being handled in this manner. Until we find a better way I suppose this works.

**Changes proposed**:

- Felhunters have innate magic resistance, equal to twice its masters level.

**Issues addressed**: Fixes #182

**Tests performed**: (Does it build, tested in-game, etc)
Builds, tested in game with proper results

**Known issues and TODO list**:

- Not related to this but the aura aquired from the Master Demonologist talent (23825) is not updated on level up, resulting in minor miscalculations. I think it should be updated/reapplied on level change.
