### PR TITLE
Fix traps arming time as described in #188

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -517,11 +517,7 @@ void GameObject::Update(uint32 diff)
                 case GAMEOBJECT_TYPE_TRAP:
                 {
                     // Arming Time for GAMEOBJECT_TYPE_TRAP (6)
-                    Unit* owner = GetOwner();
-                    if (owner && owner->IsInCombat())
-                        m_cooldownTime = GetMap()->GetGameTimeMS() + GetGOInfo()->GetCooldown() * SECOND * IN_MILLISECONDS;
-                    else if (GetEntry() == 180647)
-                        m_cooldownTime = GetMap()->GetGameTimeMS() + GetGOInfo()->GetCooldown() * SECOND * IN_MILLISECONDS;
+                    m_cooldownTime = GetMap()->GetGameTimeMS() + GetGOInfo()->GetCooldown() * IN_MILLISECONDS;
                     m_lootState = GO_READY;
                     break;
                 }
@@ -628,9 +624,6 @@ void GameObject::Update(uint32 diff)
                 if (!this->IsInWorld())
                     return;
 
-                if (m_cooldownTime > GetMap()->GetGameTimeMS())
-                    break;
-
                 // Type 2 (bomb) does not need to be triggered by a unit and despawns after casting its spell.
                 if (goInfo->trap.type == 2)
                 {
@@ -686,7 +679,11 @@ void GameObject::Update(uint32 diff)
                 }
 
                 if (target)
+                {
+                    if (target->IsInCombat() && GetMap()->GetGameTimeMS() < m_cooldownTime)
+                        break;
                     SetLootState(GO_ACTIVATED, target); //make target activate this gameobject. This will trigger trap spell in GO_ACTIVATED.
+                }
             }
 
             if (m_charges && m_usetimes >= m_charges)


### PR DESCRIPTION
**Changes proposed**:

Activate hunter traps if: 
- Target is not in combat.
- Target is in combat and cooldown time (arming time) has passed.

**Issues addressed**: Fixes #188 

**Tests performed**: (Does it build, tested in-game, etc)
Builds, tested in game and works as described in #188 in the "Desired" section of the description.

